### PR TITLE
Bound methods from original KDObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 
+0.0.6 / 2015-01-03
+==================
+
+ * package.json: Increase version - 0.0.6
+ * add KDObject#lazyBound
+ * add KDObject#bound
+
 0.0.5 / 2014-12-22
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kdf-core",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Core module of KDFramework",
   "main": "lib/index.js",
   "repository": {

--- a/src/object.coffee
+++ b/src/object.coffee
@@ -135,3 +135,25 @@ module.exports = class KDObject
     Object.defineProperty this, property, options
 
 
+  ###*
+   * Defines a cached version of given prototype
+   * method and binds the correct context into it.
+   * It makes things easier for things like event handlers.
+   *
+   * @param {String} method - Prototype method name
+   * @return {Function} a function with the bound context.
+  ###
+  bound: (method) ->
+
+    unless typeof this[method] is 'function'
+      throw new Error "bound: unknown method! #{method}"
+
+    boundMethod = "__bound__#{method}"
+
+    return this[boundMethod]  if this[boundMethod]
+
+    Object.defineProperty this, boundMethod, { value: this[method].bind this }
+
+    return this[boundMethod]
+
+

--- a/src/object.coffee
+++ b/src/object.coffee
@@ -140,7 +140,7 @@ module.exports = class KDObject
    * method and binds the correct context into it.
    * It makes things easier for things like event handlers.
    *
-   * @param {String} method - Prototype method name
+   * @param {String} method - Instance method name
    * @return {Function} a function with the bound context.
   ###
   bound: (method) ->
@@ -155,5 +155,20 @@ module.exports = class KDObject
     Object.defineProperty this, boundMethod, { value: this[method].bind this }
 
     return this[boundMethod]
+
+
+  ###*
+   * Returns a function with given arguments
+   * already passed with the correct context bound.
+   *
+   * @param {String} method - Instance method name
+   * @param {...*} args - Arguments to be passed
+  ###
+  lazyBound: (method, args...) ->
+
+    unless typeof this[method] is 'function'
+      throw new Error "lazyBound: unknown method! #{method}"
+
+    return this[method].bind this, args...
 
 

--- a/test/object-test.coffee
+++ b/test/object-test.coffee
@@ -163,3 +163,23 @@ describe 'KDObject', ->
       expect(boundAgain()).toBe 'foo'
 
 
+  describe '#lazyBound', ->
+
+    class TestObject extends KDObject
+
+      foo: (a, b, c) -> 'lazyBound' + a + b + c
+
+    it "throws when method doesn't exist", ->
+
+      object = new TestObject
+      expect(-> object.lazyBound 'bar').toThrow new Error "lazyBound: unknown method! bar"
+
+
+    it "returns a function with bound arguments", ->
+
+      object = new TestObject
+      bound = object.lazyBound 'foo', 'bar', 'baz', 'qux'
+
+      expect(bound()).toBe 'lazyBoundbarbazqux'
+
+

--- a/test/object-test.coffee
+++ b/test/object-test.coffee
@@ -132,3 +132,34 @@ describe 'KDObject', ->
       expect(object.qux).toBe 'hello world'
 
 
+  describe '#bound', ->
+
+    class BoundTestObject extends KDObject
+
+      foo: -> 'foo'
+
+    it "throws when method doesn't exist", ->
+
+      object = new BoundTestObject
+      expect(-> object.bound 'bar').toThrow new Error "bound: unknown method! bar"
+
+    it "defines a bound version of method with a prefix with correct context", ->
+
+      object = new BoundTestObject
+      bound = object.bound 'foo'
+
+      expect(object.__bound__foo).toBeDefined()
+      expect(object.__bound__foo()).toBe 'foo'
+
+
+    it "reuses already defined version of bound method, doesn't create new one", ->
+
+      object = new BoundTestObject
+
+      bound = object.bound 'foo'
+      boundAgain = object.bound 'foo'
+
+      expect(bound).toBe boundAgain
+      expect(boundAgain()).toBe 'foo'
+
+


### PR DESCRIPTION
This PR introduces `KDObject#bound` and `KDObject#lazyBound` to the core. 

Those are borrowed from [`koding/kd/core/object`](https://github.com/koding/kd/blob/master/src/core/object.coffee#L34-L43)
